### PR TITLE
BUG: fix whitespace bugs in polyinstantiation.md and reference_policy.md

### DIFF
--- a/src/polyinstantiation.md
+++ b/src/polyinstantiation.md
@@ -54,6 +54,7 @@ files to be configured:
     login configuration file (e.g. login, sshd, gdm etc.). Fedora
     already has these entries configured, with an example
     */etc/pam.d/gdm-password* file being:
+
 ```
 auth     [success=done ignore=ignore default=bad] pam_selinux_permit.so
 auth        substack      password-auth
@@ -84,7 +85,6 @@ session     include       postlogin
     [*namespace.conf*](#namespace.conf-configuration-file) section,
     with the default entries in Fedora being (note that the entries are
     commented out in the distribution):
-
 ```
 # polydir  instance-prefix     method  list_of_uids
 /tmp       /tmp-inst/          level   root,adm

--- a/src/reference_policy.md
+++ b/src/reference_policy.md
@@ -1509,6 +1509,7 @@ The basic steps are:
 1.  Edit the *build.conf* file to reflect the policy to be built (as
     this is an earlier version of the Reference Policy it has less
     options than the current Reference Policy):
+
 ```
 ############################################
 # Policy build options


### PR DESCRIPTION
This PR fixes whitespace bugs in two source MD files which cause problems with formatting and links (notably in the TOC) in the generated HTML page.

I'm not sure exactly what the problems were.  I just deleted and re-added some apparently blank lines.