### PR TITLE
BUF: fix typos in Object Classes and Permissions

### DIFF
--- a/src/object_classes_permissions.md
+++ b/src/object_classes_permissions.md
@@ -1752,7 +1752,7 @@ These socket classes that were introduced by the
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><strong>Permissions</strong></td>
-<td style="background-color:#F2F2F2;"><strong>Description</strong> (Inherit 21 common socket permissions + 1unique)</td>
+<td style="background-color:#F2F2F2;"><strong>Description</strong> (Inherit 21 common socket permissions + 1 unique)</td>
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><a href="#common-socket-permissions"><strong>Inherit Common Socket Permissions</strong></a></td>

--- a/src/object_classes_permissions.md
+++ b/src/object_classes_permissions.md
@@ -773,7 +773,7 @@ inherited by the X-Windows *x_keyboard* and *x_pointer* object classes.
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><a href="#common-file-permissions"><strong>Inherit Common File Permissions</strong></a></td>
-<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads, write</td>
+<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads,</em> write</td>
 </tr>
 <tr>
 <td>entrypoint</td>
@@ -796,11 +796,11 @@ inherited by the X-Windows *x_keyboard* and *x_pointer* object classes.
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><strong>Permissions</strong></td>
-<td style="background-color:#F2F2F2;"><strong>Description </strong>(Inherit 25 common file permissions + 2 unique)</td>
+<td style="background-color:#F2F2F2;"><strong>Description </strong>(Inherit 25 common file permissions)</td>
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><a href="#common-file-permissions"><strong>Inherit Common File Permissions</strong></a></td>
-<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads, write</td>
+<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads,</em> write</td>
 </tr>
 </tbody>
 </table>
@@ -815,11 +815,11 @@ inherited by the X-Windows *x_keyboard* and *x_pointer* object classes.
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><strong>Permissions</strong></td>
-<td style="background-color:#F2F2F2;"><strong>Description </strong>(Inherit 25 common file permissions + 2 unique)</td>
+<td style="background-color:#F2F2F2;"><strong>Description </strong>(Inherit 25 common file permissions)</td>
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><a href="#common-file-permissions"><strong>Inherit Common File Permissions</strong></a></td>
-<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads, write</td>
+<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads,</em> write</td>
 </tr>
 </tbody>
 </table>
@@ -834,11 +834,11 @@ inherited by the X-Windows *x_keyboard* and *x_pointer* object classes.
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><strong>Permissions</strong></td>
-<td style="background-color:#F2F2F2;"><strong>Description </strong>(Inherit 25 common file permissions + 2 unique)</td>
+<td style="background-color:#F2F2F2;"><strong>Description </strong>(Inherit 25 common file permissions)</td>
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><a href="#common-file-permissions"><strong>Inherit Common File Permissions</strong></a></td>
-<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads, write</td>
+<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads,</em> write</td>
 </tr>
 </tbody>
 </table>
@@ -853,11 +853,11 @@ inherited by the X-Windows *x_keyboard* and *x_pointer* object classes.
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><strong>Permissions</strong></td>
-<td style="background-color:#F2F2F2;"><strong>Description </strong>(Inherit 25 common file permissions + 2 unique)</td>
+<td style="background-color:#F2F2F2;"><strong>Description </strong>(Inherit 25 common file permissions)</td>
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><a href="#common-file-permissions"><strong>Inherit Common File Permissions</strong></a></td>
-<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads, write</td>
+<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads,</em> write</td>
 </tr>
 </tbody>
 </table>
@@ -872,11 +872,11 @@ inherited by the X-Windows *x_keyboard* and *x_pointer* object classes.
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><strong>Permissions</strong></td>
-<td style="background-color:#F2F2F2;"><strong>Description </strong>(Inherit 25 common file permissions + 2 unique)</td>
+<td style="background-color:#F2F2F2;"><strong>Description </strong>(Inherit 25 common file permissions)</td>
 </tr>
 <tr>
 <td style="background-color:#F2F2F2;"><a href="#common-file-permissions"><strong>Inherit Common File Permissions</strong></a></td>
-<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads, write</td>
+<td style="background-color:#F2F2F2;">append, audit_access, create, execute, execmod, getattr, ioctl, link, lock, map, mounton, open, quotaon, read, relabelfrom, relabelto, rename, setattr, unlink,<em> watch, watch_mount, watch_sb, watch_with_perm, watch_reads,</em> write</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Fix a few minor issues
* remove extra reference to unique permissions for *_file classes
* fix emphasis in *_file classes to exclude write
* spacing in icmp_socket

Signed-off-by: Chad Hanson <dahchanson@gmail.com>