### PR TITLE
RFE: remove a restriction about alias_id of type statement

### DIFF
--- a/src/type_statements.md
+++ b/src/type_statements.md
@@ -48,13 +48,13 @@ The *type* identifier.
 *alias*
 
 Optional *alias* keyword that signifies alternate identifiers for the *type_id*
-that are declared in the *alias_id* list.
+that are declared in the *alias_id* list. An alternative way to specify aliases
+is to use the [*typealias*](#typealias) statement.
 
 *alias_id*
 
-One or more *alias* identifiers that have been previously declared by the
-[*typealias*](#typealias) statement. Multiple entries consist of a space
-separated list enclosed in braces '{}'.
+One or more *alias* identifiers. Multiple entries consist of a space separated
+list enclosed in braces '{}'.
 
 *attribute_id*
 


### PR DESCRIPTION
Alias identifiers in a type statement don't have to be declared by
a typealias statement.

The alias identifiers in the type statement are treated as the same way
as alias identifiers in a typealias statement. [1] and [2] show my study.

[1] Alias identifiers in a type statement is processed in add_aliases_to_type()
    called from define_type() in checkpolicy/policy_define.c.
[2] Alias identifiers in a typealias statement is processed in add_aliases_to_type()
    called from define_typealias() in checkpolicy/policy_define.c.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>