### PR TITLE
BUG: fix type_member definition

### DIFF
--- a/src/type_statements.md
+++ b/src/type_statements.md
@@ -670,7 +670,7 @@ section for more details.
 **The statement definition is:**
 
 ```
-member_type source_type target_type : class member_type;
+type_member source_type target_type : class member_type;
 ```
 
 **Where:**


### PR DESCRIPTION
The keyword is `type_member`, not `member_type`.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>