### PR TITLE
notebook: fix spellings

### DIFF
--- a/src/apache_support.md
+++ b/src/apache_support.md
@@ -5,7 +5,7 @@
 
 Apache web servers are supported by SELinux using the Apache policy
 modules from the Reference Policy (*httpd* modules), however there is no
-specific Apache object manger. There is though an SELinux-aware shared
+specific Apache object manager. There is though an SELinux-aware shared
 library and policy that will allow finer grained access control when
 using Apache with threads. The additional Apache module is called
 *mod_selinux.so* and has a supporting policy module called *mod_selinux.pp*.

--- a/src/auditing.md
+++ b/src/auditing.md
@@ -255,7 +255,7 @@ subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null)
 
 Change boolean value - *MAC_CONFIG_CHANGE* - This event was generated
 when ***setsebool**(8)* was run to change a boolean. Note that the
-bolean name plus new and old values are shown in the
+boolean name plus new and old values are shown in the
 *MAC_CONFIG_CHANGE* type event with the *SYSCALL* event showing what
 process executed the change.
 

--- a/src/class_permission_statements.md
+++ b/src/class_permission_statements.md
@@ -129,7 +129,7 @@ common database { create drop getattr setattr relabelfrom relabelto }
 
 ## *class* (2)
 
-Inherit and / or associate permissions to a perviously declared *class*
+Inherit and / or associate permissions to a previously declared *class*
 identifier.
 
 **The statement definition is:**

--- a/src/configuration_files.md
+++ b/src/configuration_files.md
@@ -168,7 +168,7 @@ There is no man page for '*pp*', however the help text is as follows:
 ```
 Usage: pp [OPTIONS] [IN_FILE [OUT_FILE]]
 
-Read an SELinux policy package (.pp) and output the equivilent CIL.
+Read an SELinux policy package (.pp) and output the equivalent CIL.
 If IN_FILE is not provided or is -, read SELinux policy package from
 standard input. If OUT_FILE is not provided or is -, output CIL to
 standard output.

--- a/src/embedded_systems.md
+++ b/src/embedded_systems.md
@@ -22,7 +22,7 @@ the main emphasis on policy development as this is considered the most difficult
 area.
 The major difference between OpenWrt and Android is that SELinux is not tightly
 integrated in OpenWrt, therefore MAC is addressed in policy rather than also
-adding additional SELinux-awareness to services as in Andriod[^fn_em_1].
+adding additional SELinux-awareness to services as in Android[^fn_em_1].
 
 An alternative MAC service to consider is [**Smack**](http://www.schaufler-ca.com/)
 (Simplified Mandatory Access Control Kernel) as used in the Samsung
@@ -209,7 +209,7 @@ If there is a need to support ***xattr**(7)* filesystems on the target then
 these need to be labeled via the ***file_contexts**(5)* file that would be
 generated as part of the initial policy build.
 
-For example RAM based filesystems will require labeling before use (as Andriod
+For example RAM based filesystems will require labeling before use (as Android
 does). To achieve this either ***setfiles**(8)* or ***restorecon**(8)* will
 need to be run.
 
@@ -471,7 +471,7 @@ basic policy that can be explored as described below that does not require
 obtaining the full AOSP source and build environment.
 
 [**Android - The SELinux Policy**](seandroid.md#the-selinux-policy) section
-descibes how an Android policy is constructed using ***m4**(1)* macros, *\*.te*
+describes how an Android policy is constructed using ***m4**(1)* macros, *\*.te*
 files etc., similar to the
 [**Reference Policy**](reference_policy.md#the-reference-policy).
 

--- a/src/libselinux_functions.md
+++ b/src/libselinux_functions.md
@@ -143,7 +143,7 @@ the netlink socket in its own main loop.
 *avc_netlink_open* - *avc.h*
 
 Release netlink socket fd. Returns ownership of the netlink socket to the
-ibrary.
+library.
 
 *avc_netlink_release_fd* - *avc.h*
 

--- a/src/mls_statements.md
+++ b/src/mls_statements.md
@@ -361,13 +361,13 @@ range_transition initrc_t cupsd_exec_t:process s15:c0.c255;
 
 ## *mlsconstrain*
 
-This is decribed in the
+This is described in the
 [**Constraint Statements - *mlsconstrain***](constraint_statements.md#mlsconstrain)
 section.
 
 ## *mlsvalidatetrans*
 
-This is decribed in the
+This is described in the
 [**Constraint Statements - *mlsvalidatetrans***](constraint_statements.md#mlsvalidatetrans)
 section.
 

--- a/src/notebook-examples/cil-policy/README.md
+++ b/src/notebook-examples/cil-policy/README.md
@@ -36,7 +36,7 @@ your policy.
 
 The cil-policy addresses some of the intricacies involved with getting
 started without making assumptions about your environment and
-requirements. You are enouraged to leverage CIL to its full potential
+requirements. You are encouraged to leverage CIL to its full potential
 and to keep its documentation handy.
 
 ## Getting started

--- a/src/notebook-examples/cil-policy/cil-policy.cil
+++ b/src/notebook-examples/cil-policy/cil-policy.cil
@@ -333,7 +333,7 @@
 ;; The individually declared security identifiers have to be authorized to
 ;; associate to be able to combine into valid security contexts.
 ;;
-;; Authorize the sys.id user with s0 lavel association.
+;; Authorize the sys.id user with s0 level association.
 ;;
 
 (userlevel sys.id (s0))

--- a/src/notebook-examples/selinux-policy/README.md
+++ b/src/notebook-examples/selinux-policy/README.md
@@ -6,7 +6,7 @@ This area contains the following:
 
 ***tools*** - Contains the `build-sepolicy` script and man page. This is used
 to build the kernel and CIL policy files. It does have many hardcoded items.
-Another basic kernel policy build is avilable in the kernel source, see the
+Another basic kernel policy build is available in the kernel source, see the
 *scripts/selinux/mdp* and *Documentation/admin-guide/LSM/SELinux.rst* files.
 
 ***cil*** - Contains the CIL_Reference_Guide, Makefile to build CIL policy

--- a/src/notebook-examples/selinux-policy/tools/build-sepolicy
+++ b/src/notebook-examples/selinux-policy/tools/build-sepolicy
@@ -815,7 +815,7 @@ def usage():
     usage += '\n'
     usage += ' -k\tOutput kernel classes only (exclude # userspace entries in the\n\tsecurity_classes file).\n'
     usage += ' -M\tOutput an MLS policy.\n'
-    usage += ' -c\tOutput a policy in CIL language (otherwise gererate a kernel policy\n\tlanguage policy).\n'
+    usage += ' -c\tOutput a policy in CIL language (otherwise generate a kernel policy\n\tlanguage policy).\n'
     usage += ' -p\tOutput a file containing class and classpermissionsets + their order\n\tfor use by CIL policies.\n'
     usage += ' -s\tOutput a file containing initial SIDs + their order for use by\n\tCIL policies.\n'
     usage += ' -o\tThe output file that will contain the policy source or header file.\n'

--- a/src/notebook-examples/selinux-policy/tools/build-sepolicy.md
+++ b/src/notebook-examples/selinux-policy/tools/build-sepolicy.md
@@ -11,7 +11,7 @@ Usage: build-sepolicy [-k] [-M] [-c|-p|-s] -d flask_directory -o output_file
 	-k	Output kernel classes only (exclude # userspace entries in the
 		security_classes file).
 	-M	Output an MLS policy.
-	-c	Output a policy in CIL language (otherwise gererate a kernel policy
+	-c	Output a policy in CIL language (otherwise generate a kernel policy
 		language policy).
 	-p	Output a file containing class and classpermissionsets + their order
 		for use by CIL policies.

--- a/src/object_classes_permissions.md
+++ b/src/object_classes_permissions.md
@@ -1382,7 +1382,7 @@ Netlink socket to support RFC 3720 - Internet Small Computer Systems Interface
 
 ### *netlink_fib_lookup_socket*
 
-Netlink socket to Forwarding Informaton Base services.
+Netlink socket to Forwarding Information Base services.
 
 **Permissions** - Inherit 21
 [**Common Socket Permissions**](#common-socket-permissions):
@@ -1480,7 +1480,7 @@ and label packets, SELinux then enforces policy using these packet labels.
 
 *forward_in*
 
-- Allow inbound forwaded packets.
+- Allow inbound forwarded packets.
 
 *forward_out*
 
@@ -1597,7 +1597,7 @@ Internet Control Message Protocol (ICMP)
 - *ieee802154_socket* - For low-rate wireless personal area networks (LR-WPANs).
 - *caif_socket* - Communication CPU to Application CPU Interface
 - *alg_socket* - algorithm interface
-- *nfc_socket* - Near Field Commuications
+- *nfc_socket* - Near Field Communications
 - *vsock_socket* - Virtual Socket protocol
 - *kcm_socket* - Kernel Connection Multiplexor
 - *qipcrtr_socket* - communicating with services running on co-processors in
@@ -2762,11 +2762,11 @@ Manage a database.
 
 *install_module*
 
-- Required to install a dynmic link library.
+- Required to install a dynamic link library.
 
 *load_module*
 
-- Required to load a dynmic link library.
+- Required to load a dynamic link library.
 
 ### *db_table*
 

--- a/src/policy_config_files.md
+++ b/src/policy_config_files.md
@@ -778,7 +778,7 @@ system_u:object_r:removable_t:s0
 ## *contexts/sepgsql_contexts*
 
 This file contains the default security contexts for SE-PostgreSQL
-database objects and is descibed in ***selabel_db**(5)*.
+database objects and is described in ***selabel_db**(5)*.
 
 **The file format is as follows:**
 
@@ -1059,7 +1059,7 @@ compatible regular expression (PCRE) internal format.
 This file is added by the ***semanage fcontext*** command as described in the
 [*active/file_contexts.local*](policy_store_config_files.md#activefile_contexts.local)
 file section to allow locally defined files to be labeled correctly. The
-***file_contexts**(5)* man page also decribes this file.
+***file_contexts**(5)* man page also describes this file.
 
 **Supporting libselinux API functions are:**
 
@@ -1077,7 +1077,7 @@ contexts on the users home directory and files.
 
 It is fully described in the
 [*active/file_contexts.homedirs*](policy_store_config_files.md#activefile_contexts.homedirs)
-file section. The ***file_contexts**(5)* man page also decribes this
+file section. The ***file_contexts**(5)* man page also describes this
 file.
 
 There may also be a *file_contexts.homedirs.bin* present that is built
@@ -1095,7 +1095,7 @@ Perl compatible regular expression (PCRE) internal format.
 These files allow substitution of file names (*.subs* for local use and
 *.subs_dist* for GNU / Linux distributions use) for the *libselinux*
 function ***selabel_lookup**(3)*. The ***file_contexts**(5)* man page also
-decribes this file.
+describes this file.
 
 The subs files contain a list of space separated path names such as:
 
@@ -1162,7 +1162,7 @@ These optional files are named after the SELinux user they represent.
 Each file has the same format as the
 [*contexts/default_contexts*](#contextsdefault_contexts) file and
 is used to assign the correct context to the SELinux user (generally
-during login). The ***user_contexts**(5)* man page also decribes these
+during login). The ***user_contexts**(5)* man page also describes these
 entries.
 
 **Example file contents** - From the 'targeted` *unconfined_u* file:
@@ -1201,7 +1201,7 @@ and level based on the GNU / Linux login id and service name. It has
 been implemented for SELinux-aware applications such as FreeIPA
 (Identity, Policy Audit - see
 [http://freeipa.org/page/Main_Page](http://freeipa.org/page/Main_Page)
-for details). The ***service_seusers**(5)* man page also decribes these
+for details). The ***service_seusers**(5)* man page also describes these
 entries.
 
 The file name is based on the GNU/Linux user that is used at log in time

--- a/src/postgresql.md
+++ b/src/postgresql.md
@@ -69,7 +69,7 @@ Using **Figure 24a: SE-PostgreSQL Services**, the database client application
 (that could be provided by an API for Perl/PHP or some other programming
 language) connects to a database and executes SQL commands. As the SQL
 commands are processed by PostgreSQL, each operation performed on an object
-is checked by the object manager (OM) to see if the opration is allowed
+is checked by the object manager (OM) to see if the operation is allowed
 by the security policy or not.
 
 ![](./images/24a-sepostgresql.png)

--- a/src/reference_policy.md
+++ b/src/reference_policy.md
@@ -1317,7 +1317,7 @@ UNK_PERMS = deny
 
 # Direct admin init
 # Setting this will allow sysadm to directly
-# run init scripts, instead of requring run_init.
+# run init scripts, instead of requiring run_init.
 # This is a build option, as role transitions do
 # not work in conditional policy.
 DIRECT_INITRC = n

--- a/src/seandroid.md
+++ b/src/seandroid.md
@@ -220,7 +220,7 @@ All Android kernels support the Linux Security Module (LSM) and SELinux
 services, however they are based on various versions, therefore the latest
 SELinux enhancements may not always be present. The
 [**Kernel LSM / SELinux Support**](#kernel-lsm-selinux-support) section
-describes the Andriod kernel changes and the
+describes the Android kernel changes and the
 [**Linux Security Module and SELinux**](lsm_selinux.md#linux-security-module-and-selinux)
 section describes the core SELinux services in the kernel.
 
@@ -676,7 +676,7 @@ formats are detailed in the
 [Policy File Formats](#policy-file-formats)
 section.
 
-These comments have been extracted from *system/sepolicy/Andoid.mk*, there
+These comments have been extracted from *system/sepolicy/Android.mk*, there
 are many useful comments in this file regarding its build.
 
 ```
@@ -1199,7 +1199,7 @@ file:
 # user=_isolated will match any isolated service process.
 # Other values of user are matched against the name associated with the process
 # UID.
-# seinfo= matches aginst the seinfo tag for the app, determined from
+# seinfo= matches against the seinfo tag for the app, determined from
 # mac_permissions.xml files.
 # The ':' character is reserved and may not be used in seinfo.
 # name= matches against the package name of the app.
@@ -1571,7 +1571,7 @@ An example *keys.conf* file from *system/sepolicy/private* is as follows:
 # name it after the base file name of the pem file.
 #
 # Each tag (section) then allows one to specify any string found in
-# TARGET_BUILD_VARIANT. Typcially this is user, eng, and userdebug. Another
+# TARGET_BUILD_VARIANT. Typically this is user, eng, and userdebug. Another
 # option is to use ALL which will match ANY TARGET_BUILD_VARIANT string.
 #
 

--- a/src/security_context.md
+++ b/src/security_context.md
@@ -66,7 +66,7 @@ However note that:
        based on their object class.
 
 The [**Computing Security Contexts**](computing_security_contexts.md#computing-security-contexts)
-section decribes how SELinux computes the security context components based
+section describes how SELinux computes the security context components based
 on a *source context*, *target context* and object *class*.
 
 The examples below show security contexts for processes, directories and files

--- a/src/selinux_overview.md
+++ b/src/selinux_overview.md
@@ -30,7 +30,7 @@ SELinux is not just for military or high security systems where
 Multi-Level Security (MLS) is required (for functionality such as 'no
 read up' and 'no write down'), as using the 'type enforcement' (TE)
 functionality applications can be confined (or contained) within domains
-and limited to the mimimum privileges required to do their job, so in a
+and limited to the minimum privileges required to do their job, so in a
 'nutshell':
 
 1.  **The First Security Principle:** ***Trust nothing, trust nobody, all
@@ -92,7 +92,7 @@ The following maybe useful in providing a practical view of SELinux:
     <http://blog.ptsecurity.com/2012/08/selinux-in-practice-dvwa-test.html>,
     and this is a response to the study:
     <http://danwalsh.livejournal.com/56760.html>.
-3.  SELinux services have been added to Andriod. The presentation
+3.  SELinux services have been added to Android. The presentation
     "Security Enhancements (SE) for Android gives use-cases and
     types of Android exploits that SELinux could have overcome. The
     presentation and others are available at:

--- a/src/terminology.md
+++ b/src/terminology.md
@@ -175,7 +175,7 @@ modules
 
 **Mandatory Access Control**
 
-An access control mechanisim enforced by the system. This can be achieved
+An access control mechanism enforced by the system. This can be achieved
 by 'hard-wiring' the operating system and applications or via a policy that
 conforms to a **Policy**. Examples of policy based MAC are **SELinux** and SMACK.
 
@@ -218,7 +218,7 @@ into a binary format for loading into the **Security Server**.
 SELinux users are associated to one or more roles, each role may then be
 associated to one or more **Domain** types.
 
-**Role Based Access Control-Seperation**
+**Role Based Access Control-Separation**
 
 Role-based separation of user home directories. An optional policy tunable is
 required: *tunableif enable_rbacsep*

--- a/src/type_statements.md
+++ b/src/type_statements.md
@@ -452,7 +452,7 @@ permissive unconfined_t;
 ## *type_transition*
 
 The type_transition rule specifies the default type to be used for
-domain transistion or object creation. Kernels from 2.6.39 with Policy
+domain transition or object creation. Kernels from 2.6.39 with Policy
 versions from 25 also support the 'name transition rule' extension. See the
 [**Computing Security Contexts**](computing_security_contexts.md#computing-security-contexts)
 section for more details. Note than an *allow* rule must be used to authorise

--- a/src/xen_statements.md
+++ b/src/xen_statements.md
@@ -39,7 +39,7 @@ The *iomemcon* keyword.
 *addr*
 
 The memory address to apply the context. This may also be a range that consists
-of a start and end address separated by a hypen \'-\'.
+of a start and end address separated by a hyphen \'-\'.
 
 *context*
 
@@ -85,7 +85,7 @@ The *ioportcon* keyword.
 *port*
 
 The *port* to apply the context. This may also be a range that consists of a
-start and end port number separated by a hypen \'-\'.
+start and end port number separated by a hyphen \'-\'.
 
 *context*
 
@@ -130,7 +130,7 @@ The *pcidevicecon* keyword.
 
 *pci_id*
 
-The PCI indentifer.
+The PCI identifier.
 
 *context*
 


### PR DESCRIPTION
Found by codespell(1) and typos[1].

[1]: https://github.com/crate-ci/typos

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>