### PR TITLE
RFE: object_classes_permissions: add io_uring class

### DIFF
--- a/src/object_classes_permissions.md
+++ b/src/object_classes_permissions.md
@@ -89,6 +89,7 @@
     - [*key*](#key)
     - [*memprotect*](#memprotect)
     - [*binder*](#binder)
+    - [*io_uring*](#io_uring)
   - [Capability Object Classes](#capability-object-classes)
     - [*capability*](#capability)
     - [*capability2*](#capability2)
@@ -974,9 +975,15 @@ type_transition sysadm_t sysadm_t : anon_inode uffd_t "[userfaultfd]";
 allow sysadm_t uffd_t:anon_inode { create };
 ```
 
-Currently only ***userfaultfd**(2)* makes use of this service (from kernel 5.12)
-as described in the patch series
-<https://lore.kernel.org/selinux/20210108222223.952458-1-lokeshgidra@google.com/>
+The current implementations that make use of this service are:
+
+- ***userfaultfd**(2)* (from kernel 5.12) described in the patch series
+  <https://lore.kernel.org/selinux/20210108222223.952458-1-lokeshgidra@google.com/>
+
+- ***io_uring**(7)* (from kernel 5.16) described in the patch series
+  <https://lore.kernel.org/all/163172459001.88001.17463922586800990358.stgit@olly/>
+
+
 
 **Permissions** - Inherit 25
 [**Common File Permissions**](#common-file-permissions):
@@ -2142,6 +2149,26 @@ Manage the Binder IPC service.
 
 - Transfer a binder reference to another process (can A transfer a binder
   reference to B?).
+
+### *io_uring*
+
+Manage security-sensitive usages of the *io_uring* subsystem.
+
+**Permission** - 3 unique permissions:
+
+*override_creds*
+
+- Use another process's credentials via an *io_uring* personality (Can A use B's
+  credentials when calling ***io_uring_enter**(2)*?).
+  Personalities are explained in ***io_uring_register**(2)*.
+
+*sqpoll*
+
+- Use an *io_uring* asynchronous polling thread.
+
+*cmd*
+
+- Use *IORING_OP_URING_CMD* on a given file.
 
 ## Capability Object Classes
 

--- a/src/object_classes_permissions.md
+++ b/src/object_classes_permissions.md
@@ -983,7 +983,8 @@ The current implementations that make use of this service are:
 - ***io_uring**(7)* (from kernel 5.16) described in the patch series
   <https://lore.kernel.org/all/163172459001.88001.17463922586800990358.stgit@olly/>
 
-
+- ***memfd_secret**(2)* (from kernel 6.0) described in the patch
+  <https://lore.kernel.org/linux-mm/20220125143304.34628-1-cgzones@googlemail.com/>
 
 **Permissions** - Inherit 25
 [**Common File Permissions**](#common-file-permissions):
@@ -2159,8 +2160,11 @@ Manage security-sensitive usages of the *io_uring* subsystem.
 *override_creds*
 
 - Use another process's credentials via an *io_uring* personality (Can A use B's
-  credentials when calling ***io_uring_enter**(2)*?).
-  Personalities are explained in ***io_uring_register**(2)*.
+  credentials when submitting a new *io_uring* operation).
+  Personalities are explained in ***io_uring_register**(2)* and can be thought
+  of as credential references, which allow a caller to store a copy of their
+  credentials, including SELinux labels, in an *io_uring* for use by other
+  processes.
 
 *sqpoll*
 


### PR DESCRIPTION
Fills in documentation for the io_uring object class and the associated permissions. Summary of docs changes:
1. Change `anon_inode` to reflect that `io_uring` is also using type transitions in addition to `userfaultfd`.
2. Add an `io_uring` section documenting the three permissions, `override_creds`, `sqpoll`, and `cmd`.

This change was tested by running `make all` and verifying formatting in Firefox and Foliate.

Signed-off-by: Gil Cukierman <cukie@google.com>