### PR TITLE
Remove note about the decade old path migration to /sys and /var/lib

### DIFF
--- a/src/selinux_overview.md
+++ b/src/selinux_overview.md
@@ -10,16 +10,6 @@ was enhanced by the NSA and released as open source software (see:
 Each of the sections that follow will describe a component of SELinux,
 and hopefully they are in some form of logical order.
 
-Note: When SELinux is installed, there are three well defined directory
-locations referenced. Two of these will change with the old and new
-locations as follows:
-
-| Description | Old Location | New Location |
-| :---------  | :----------- | :----------- |
-The SELinux filesystem that interfaces with the kernel based security server. The new location has been available since Fedora 17. | */selinux* | */sys/fs/selinux* |
-| The SELinux configuration directory that holds the sub-system configuration files and policies. | */etc/selinux* | No change |
-| The SELinux policy store that holds policy modules and configuration details. The new location has been available since Fedora 23. | */etc/selinux/\<SELINUXTYPE\>/module* | */var/lib/selinux/\<SELINUXTYPE\>* |
-
 ## Is SELinux useful
 
 There are many views on the usefulness of SELinux on Linux based


### PR DESCRIPTION
Front and center at the start of the book is a notice about a path migration from `/selinux` to `/sys/fs/selinux`, and from `/etc/selinux/<TYPE>/module` to `/var/lib/selinux/<TYPE>`. The former change happened in Fedora 17, released in 2012 (12 years ago). The latter was in Fedora 23, released 2015 (9 years ago).

As far as I could find, there are no mainline linux distros that still support releases that old, except maybe for RHEL 7, and then only for customers who pay for the "extended extended" life support contract, for everyone else it hit EOL earlier this year. If they're the only ones left, it seems reasonable to let Redhat handle it in their own documentation.

I think it's reasonable to call the migration "complete" by now, and not distract new SELinux users with it :)