### PR TITLE
Switch to v4 of the upload-artifact github action in CI

### DIFF
--- a/.github/workflows/epub.yml
+++ b/.github/workflows/epub.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run the build
       run: make epub
     - name: Archive the rendering
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: EPUB rendering
         path: ./epub/SELinux_Notebook.azw3

--- a/.github/workflows/html.yml
+++ b/.github/workflows/html.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run the build
       run: make html
     - name: Archive the rendering
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: HTML rendering
         path: ./html/SELinux_Notebook.html

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run the build
       run: make pdf
     - name: Archive the rendering
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: PDF rendering
         path: ./pdf/SELinux_Notebook.pdf


### PR DESCRIPTION
v3 has been deprecated and is no longer functional: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/