### PR TITLE
Switch github runners to use ubuntu-latest

### DIFF
--- a/.github/workflows/checkers.yml
+++ b/.github/workflows/checkers.yml
@@ -10,7 +10,7 @@ on: ["push", "pull_request", "workflow_dispatch"]
 
 jobs:
   codespell:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout from github

--- a/.github/workflows/epub.yml
+++ b/.github/workflows/epub.yml
@@ -10,7 +10,7 @@ on: ["push", "pull_request", "workflow_dispatch"]
 
 jobs:
   epub:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout from GitHub

--- a/.github/workflows/html.yml
+++ b/.github/workflows/html.yml
@@ -10,7 +10,7 @@ on: ["push", "pull_request", "workflow_dispatch"]
 
 jobs:
   html:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout from GitHub

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -10,7 +10,7 @@ on: ["push", "pull_request", "workflow_dispatch"]
 
 jobs:
   pdf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout from GitHub


### PR DESCRIPTION
Github actions has deprecated Ubuntu 20.04 runners:

https://github.com/actions/runner-images/issues/11101

Switch to just running on the latest ubuntu image for our runners to avoid future maintenance burden and ensure compatibility with up to date toolchains.