### PR TITLE
Fix definition of service:reload permission

### DIFF
--- a/src/object_classes_permissions.md
+++ b/src/object_classes_permissions.md
@@ -3173,15 +3173,15 @@ Manage ***systemd**(1)* services.
 
 *load*
 
-- Load services
+- Load services.
 
 *reload*
 
-- Restart *systemd* services.
+- Trigger a configuration reload in a systemd service.  Under certain configurations, reloading is equivalent to restarting.
 
 *start*
 
-- Start *systemd* services.
+- (Re)start *systemd* services.
 
 *status*
 


### PR DESCRIPTION
This permission is used for the ExecReload systemd directive and similar to trigger a configuration reload in a service.  It might result in a unit starting, but for a typical restart operation, the "start" permission is what is checked.