### PR TITLE
Explain NNP transitions

### DIFF
--- a/src/lsm_selinux.md
+++ b/src/lsm_selinux.md
@@ -729,8 +729,9 @@ or *libsepol* library.
 
 - Enables SELinux domain transitions to occur under *no_new_privs* (NNP)
   or on *nosuid* mounts if the corresponding permission (*nnp_transition*
-  for NNP, *nosuid_transition* for *nosuid*, defined in the *process2*
-  security class) is allowed between the old and new contexts.
+  for NNP, *nosuid_transition* for *nosuid*, defined in the
+  [*process2* security class](object_classes_permissions.md#process2))
+  is allowed between the old and new contexts.
 
 *policy_capabilities/open_perms*
 

--- a/src/object_classes_permissions.md
+++ b/src/object_classes_permissions.md
@@ -1911,6 +1911,19 @@ Extension of *process* class.
 *nnp_transition*
 
 - Enables SELinux domain transitions to occur under *no_new_privs* (*NNP*).
+- *NNP* is a flag, which a process can set on itself, that ensures that any
+  subsequent execve(2)/fork(2)/clone(2) doesn't lead to the process gaining
+  more privileges than it had before the operation. Strictly restricting
+  SELinux domain transitions under NNP in the same way would be impractical
+  and could often go against the principle of least privilege, so the writer
+  of the policy is given the choice to explicitly allow a given transition
+  under NNP where it makes sense using this permission. For example, a
+  reasonable criterion could be that the target domain and any domains that
+  it can possibly transition into are reasonably confined and it's not
+  possible to "escape" into a domain that has excess permissions (e.g.
+  an unconfined or a permissive domain).
+- See the [original kernel commit's description](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=af63f4193f9fbbbac50fc766417d74735afd87ef)
+  for more details.
 
 *nosuid_transition*
 


### PR DESCRIPTION
Provide a brief explanation of the NNP concept and how it realtes to SELinux transitions to help guide people deciding whether to allow the nnp_transtion permission or not.

---

It has been pointed out to me that the semantics behind the `nnp_transition` permission are not obvious and that it would help to have some documentation on it, so I tried to to add it here. I'm not quite sure if it's sufficiently clear and correct, so would welcome feedback.

Cc @zpytela @stephensmalley 